### PR TITLE
衝突デモのデータ保存機構の追加

### DIFF
--- a/WirelessAR_Demo/.gitignore
+++ b/WirelessAR_Demo/.gitignore
@@ -71,3 +71,6 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# User files
+*.xml

--- a/WirelessAR_Demo/Assets/Original/Scripts/CollisionData.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/CollisionData.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System.IO;
+using System.Text;
+
+/// <summary>
+/// 衝突回数データ
+/// </summary>
+public struct HitData
+{
+    /// <summary>
+    /// 出現回数
+    /// </summary>
+    public uint Appeared { get; set; }
+
+    /// <summary>
+    /// 衝突回数
+    /// </summary>
+    public uint Collided { get; set; }
+
+    /// <summary>
+    /// 回避回数
+    /// </summary>
+    public uint Avoided { get => this.Appeared - this.Collided; }
+
+    public HitData(uint appear, uint collision)
+    {
+        this.Appeared = appear;
+        this.Collided = collision;
+    }
+}
+
+/// <summary>
+/// オブジェクトの衝突データ
+/// </summary>
+public class CollisionData
+{
+    // 衝突データ
+    // (left, right)の衝突回数データを種類数だけ保持
+    List<(HitData, HitData)> _data = new List<(HitData, HitData)>(); 
+
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    /// <param name="kind_num">衝突物体の種類の数</param>
+    public CollisionData(int kind_num)
+    {
+        _data = new List<(HitData left, HitData right)>(kind_num);
+    }
+
+    /// <summary>
+    /// 指定ファイルへデータを書き込む
+    /// </summary>
+    /// <param name="path">ファイルパス</param>
+    void Write(string path, bool append = false, string encode = "shift-jis")
+    {
+        using (StreamWriter sw = new StreamWriter(path, append, Encoding.GetEncoding(encode)))
+        {
+            // foreach (string line in lines)
+            // {
+            //     sw.WriteLine(line);
+            // }
+        }
+    }
+}

--- a/WirelessAR_Demo/Assets/Original/Scripts/CollisionData.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/CollisionData.cs
@@ -5,9 +5,19 @@ using System.IO;
 using System.Text;
 
 /// <summary>
+/// 方向
+/// ターゲットの出現方角
+/// </summary>
+public enum Direction
+{
+    Left,
+    Right,
+}
+
+/// <summary>
 /// 衝突回数データ
 /// </summary>
-public struct HitData
+public class HitData
 {
     /// <summary>
     /// 出現回数
@@ -38,7 +48,7 @@ public class CollisionData
 {
     // 衝突データ
     // (left, right)の衝突回数データを種類数だけ保持
-    List<(HitData, HitData)> _data = new List<(HitData, HitData)>(); 
+    List<(HitData left, HitData right)> _data = new List<(HitData, HitData)>(); 
 
     /// <summary>
     /// コンストラクタ
@@ -46,14 +56,54 @@ public class CollisionData
     /// <param name="kind_num">衝突物体の種類の数</param>
     public CollisionData(int kind_num)
     {
-        _data = new List<(HitData left, HitData right)>(kind_num);
+        _data = new List<(HitData, HitData)>(kind_num);
+    }
+
+    /// <summary>
+    /// 出現カウントを行う
+    /// </summary>
+    /// <param name="id">ターゲットid</param>
+    /// <param name="dir">ターゲットの出現方向</param>
+    public void CountAppear(int id, Direction dir)
+    {
+        switch (dir)
+        {
+            case Direction.Left:
+                _data[id].left.Appeared++;
+                break;
+            case Direction.Right:
+                _data[id].right.Appeared++;
+                break;
+            default:
+                break;
+        }
+    }
+
+    /// <summary>
+    /// 衝突カウントを行う
+    /// </summary>
+    /// <param name="id">ターゲットid</param>
+    /// <param name="dir">ターゲットの出現方向</param>
+    public void CountHit(int id, Direction dir)
+    {
+        switch (dir)
+        {
+            case Direction.Left:
+                _data[id].left.Collided++;
+                break;
+            case Direction.Right:
+                _data[id].right.Collided++;
+                break;
+            default:
+                break;
+        }
     }
 
     /// <summary>
     /// 指定ファイルへデータを書き込む
     /// </summary>
     /// <param name="path">ファイルパス</param>
-    void Write(string path, bool append = false, string encode = "shift-jis")
+    public void Write(string path, bool append = false, string encode = "UTF-8")
     {
         using (StreamWriter sw = new StreamWriter(path, append, Encoding.GetEncoding(encode)))
         {

--- a/WirelessAR_Demo/Assets/Original/Scripts/CollisionData.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/CollisionData.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using UnityEngine;
 using System.IO;
-using System.Text;
 
 /// <summary>
 /// 方向
@@ -108,15 +107,16 @@ public class CollisionData
     /// <summary>
     /// 指定ファイルへデータを書き込む
     /// </summary>
-    /// <param name="path">ファイルパス</param>
-    public void Write(string path, bool append = false, string encode = "UTF-8")
+    /// <param name="filename">ファイル名</param>
+    public bool Write(string filename, bool append = false)
     {
-        using (StreamWriter sw = new StreamWriter(path, append, Encoding.GetEncoding(encode)))
+        var serializer = new System.Xml.Serialization.XmlSerializer(typeof(List<(HitData left, HitData right)>));
+        using (var sw = new StreamWriter(filename, append, new System.Text.UTF8Encoding(false)))
         {
-            // foreach (string line in lines)
-            // {
-            //     sw.WriteLine(line);
-            // }
+            // シリアル化
+            serializer.Serialize(sw, _data);
         }
+
+        return true;
     }
 }

--- a/WirelessAR_Demo/Assets/Original/Scripts/CollisionData.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/CollisionData.cs
@@ -22,17 +22,19 @@ public class HitData
     /// <summary>
     /// 出現回数
     /// </summary>
-    public uint Appeared { get; set; }
+    public uint Appeared { get; set; } = 0;
 
     /// <summary>
     /// 衝突回数
     /// </summary>
-    public uint Collided { get; set; }
+    public uint Collided { get; set; } = 0;
 
     /// <summary>
     /// 回避回数
     /// </summary>
     public uint Avoided { get => this.Appeared - this.Collided; }
+
+    public HitData() { }
 
     public HitData(uint appear, uint collision)
     {
@@ -57,6 +59,10 @@ public class CollisionData
     public CollisionData(int kind_num)
     {
         _data = new List<(HitData, HitData)>(kind_num);
+
+        // データ追加
+        for (int i = 0; i < kind_num; ++i)
+            _data.Add((new HitData(), new HitData()));
     }
 
     /// <summary>

--- a/WirelessAR_Demo/Assets/Original/Scripts/DemoSettings.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/DemoSettings.cs
@@ -97,6 +97,11 @@ public class DemoSettings : MonoBehaviour
 
     #endregion
 
+    /// <summary>
+    /// シーン制御（適当実装）
+    /// </summary>
+    [SerializeField] SceneController _scene;
+
 
     /// <summary>
     /// Setterを強制使用させる
@@ -127,6 +132,9 @@ public class DemoSettings : MonoBehaviour
     {
         // MEMO: 初期化時にセッター機能しないためあらためて初期化
         this.Distance = this.Distance;
+
+        // ターゲット数を設定
+        _scene.SetTargetNum(this.Colors.GetTable().Count);
     }
 
     // Update is called once per frame

--- a/WirelessAR_Demo/Assets/Original/Scripts/DemoSettings.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/DemoSettings.cs
@@ -100,7 +100,9 @@ public class DemoSettings : MonoBehaviour
     /// <summary>
     /// シーン制御（適当実装）
     /// </summary>
-    [SerializeField] SceneController _scene;
+    [SerializeField] 
+    SceneController _scene;
+    public SceneController SceneController => _scene;
 
 
     /// <summary>
@@ -110,6 +112,11 @@ public class DemoSettings : MonoBehaviour
     [CustomEditor(typeof(DemoSettings))]
     public class CustomInspector : Editor
     {
+        /// <summary>
+        /// 衝突データ保存ファイル名
+        /// </summary>
+        string _filename = @"collision_datas.xml";
+
         public override void OnInspectorGUI () 
         {
             base.OnInspectorGUI();
@@ -123,6 +130,14 @@ public class DemoSettings : MonoBehaviour
                     getterSetter.Distance = getterSetter.Distance;
                 }
             }
+
+            if (GUILayout.Button("Save to file"))
+            {
+                //!< 衝突データを保存する
+                if ((target as DemoSettings).SceneController.CollisionDatas.Write(_filename))
+                    Debug.Log("Data saved!");
+            }
+
         }
     }
 

--- a/WirelessAR_Demo/Assets/Original/Scripts/Player.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/Player.cs
@@ -15,13 +15,13 @@ public class Player : MonoBehaviour
     /// 自動で前に進ませるか（デバグ用）
     /// </summary>
     [field: SerializeField]
-    public bool IsForceForward { get; set; } = false;
+    public bool IsForceForward { get; private set; } = false;
 
     /// <summary>
     /// 移動速度
     /// </summary>
     [field: SerializeField]
-    public float Speed { get; set; } = 0.01f;
+    public float Speed { get; private set; } = 0.01f;
 
     // Start is called before the first frame update
     void Start()

--- a/WirelessAR_Demo/Assets/Original/Scripts/Player.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/Player.cs
@@ -23,6 +23,11 @@ public class Player : MonoBehaviour
     [field: SerializeField]
     public float Speed { get; private set; } = 0.01f;
 
+    /// <summary>
+    /// シーン制御（適当実装）
+    /// </summary>
+    [SerializeField] SceneController _scene;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -66,6 +71,10 @@ public class Player : MonoBehaviour
         {
             Debug.Log("Hit");
             this.Damage();
+
+            // 衝突データをカウント
+            var target = other.GetComponent<Target>();
+            _scene.CollisionDatas.CountHit(target.Id, target.Direction);
         }
     }
 

--- a/WirelessAR_Demo/Assets/Original/Scripts/SceneController.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/SceneController.cs
@@ -35,10 +35,4 @@ public class SceneController : MonoBehaviour
         // 衝突データ初期化
         _datas = new CollisionData(kind_num);
     }
-
-    // Update is called once per frame
-    void Update()
-    {
-        var a = 2;
-    }
 }

--- a/WirelessAR_Demo/Assets/Original/Scripts/SceneController.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/SceneController.cs
@@ -9,6 +9,12 @@ public class SceneController : MonoBehaviour
     /// /// </summary>
     [SerializeField] GameObject _target;
 
+    /// <summary>
+    /// 衝突回数データ群
+    /// </summary>
+    private CollisionData _datas;
+    public CollisionData CollisionDatas => _datas;
+
 
     // Start is called before the first frame update
     void Start()
@@ -16,6 +22,8 @@ public class SceneController : MonoBehaviour
         // 初期値は非表示
         // Enable, Disableで制御
         _target.SetActive(false);
+
+        // TODO: 衝突データの復元など...
     }
 
     // Update is called once per frame

--- a/WirelessAR_Demo/Assets/Original/Scripts/SceneController.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/SceneController.cs
@@ -26,9 +26,19 @@ public class SceneController : MonoBehaviour
         // TODO: 衝突データの復元など...
     }
 
+    /// <summary>
+    /// ターゲット数をもとに設定を行う
+    /// </summary>
+    /// <param name="kind_num"></param>
+    public void SetTargetNum(int kind_num)
+    {
+        // 衝突データ初期化
+        _datas = new CollisionData(kind_num);
+    }
+
     // Update is called once per frame
     void Update()
     {
-
+        var a = 2;
     }
 }

--- a/WirelessAR_Demo/Assets/Original/Scripts/SensorA.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/SensorA.cs
@@ -47,10 +47,12 @@ public class SensorA : MonoBehaviour
     {
         if (other.gameObject.CompareTag("Player"))
         {
+            // 総歩行距離歩いたか
             if (this.transform.localPosition.z > _settings.Distdata)
             {
                 if (!_fin)
                 {
+                    // メッセージボックスを正面に表示し終了
                     _msg_box.SetActive(true);
                     _fin = true;
                 }

--- a/WirelessAR_Demo/Assets/Original/Scripts/SensorA.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/SensorA.cs
@@ -20,6 +20,7 @@ public class SensorA : MonoBehaviour
 
     [SerializeField] DemoSettings _settings;
     [SerializeField] GameObject _msg_box;
+    [SerializeField] GameObject _target;
     
     Vector3 _init_pos;
     Vector3 _next_pos;
@@ -59,6 +60,8 @@ public class SensorA : MonoBehaviour
             }
             else
             {
+                _target.SetActive(false);
+
                 // 歩行開始とみなす
                 this.IsWalking = true;
                 this.Duration = 0f;

--- a/WirelessAR_Demo/Assets/Original/Scripts/SensorB.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/SensorB.cs
@@ -19,6 +19,11 @@ public class SensorB : MonoBehaviour
     /// </summary>
     [SerializeField] DemoSettings _settings;
 
+    /// <summary>
+    /// シーン制御（適当実装）
+    /// </summary>
+    [SerializeField] SceneController _scene;
+
     Vector3 _init_pos;
     Vector3 _next_pos;
 
@@ -65,15 +70,16 @@ public class SensorB : MonoBehaviour
                 // NOTE: 煩雑なのでいつか書き換え
                 Color? color = null;
                 var table = _settings.Colors.GetTable();
+                int color_id = 0;
 
                 while (color == null)
                 {
-                    var rand = Random.Range(0, table.Count);
+                    color_id = Random.Range(0, table.Count);
                     int i = 0;
 
                     foreach (var pair in table)
                     {
-                        if (i++ == rand && pair.Value == true)
+                        if (i++ == color_id && pair.Value == true)
                             color = pair.Key;
                     }
                 }
@@ -101,13 +107,10 @@ public class SensorB : MonoBehaviour
                 _target.SetActive(true);
                 _target.GetComponent<Target>().SetColor(color.Value);
 
-                // //count
-                // if(angle<=0)
-                // {discrim=color*4;}
-                // else
-                // {discrim=color*4+2;}
-                // fw.Count(discrim);
-                
+                // 出現情報を格納
+                _scene.CollisionDatas.CountAppear(
+                    color_id,
+                    angle <= 0 ? Direction.Left : Direction.Right);
             }
         }
     }

--- a/WirelessAR_Demo/Assets/Original/Scripts/SensorB.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/SensorB.cs
@@ -102,15 +102,19 @@ public class SensorB : MonoBehaviour
                 _next_pos.z += this.Distance + 1;
                 this.transform.localPosition = _next_pos;
                 _sensorA.Move(this.Distance);
+
         
                 // ターゲットを有効化
                 _target.SetActive(true);
-                _target.GetComponent<Target>().SetColor(color.Value);
+
+                // ターゲットの設定
+                var target = _target.GetComponent<Target>();
+                target.SetColor(color.Value);
+                target.Id = color_id;
+                target.Direction = angle <= 0 ? Direction.Left : Direction.Right;
 
                 // 出現情報を格納
-                _scene.CollisionDatas.CountAppear(
-                    color_id,
-                    angle <= 0 ? Direction.Left : Direction.Right);
+                _scene.CollisionDatas.CountAppear(target.Id, target.Direction);
             }
         }
     }

--- a/WirelessAR_Demo/Assets/Original/Scripts/Target.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/Target.cs
@@ -12,6 +12,17 @@ public class Target : MonoBehaviour
     float _vz;
     float _del_z = 5f; // 物体を削除する距離
 
+    /// <summary>
+    /// ターゲットID
+    /// 現在はカラー選択時のランダム値をidにしている
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// どの方向からのデータであるか
+    /// </summary>
+    public Direction Direction { get; set; }
+
 
     void Awake()
     {

--- a/WirelessAR_Demo/Assets/Original/Scripts/Target.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/Target.cs
@@ -10,7 +10,7 @@ public class Target : MonoBehaviour
     Transform _transform;
     float _vx;
     float _vz;
-    float _del_z = 3f; // 物体を削除する距離
+    float _del_z = 5f; // 物体を削除する距離
 
 
     void Awake()

--- a/WirelessAR_Demo/Assets/Original/Scripts/Target.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/Target.cs
@@ -57,9 +57,9 @@ public class Target : MonoBehaviour
         _transform.Translate(Time.deltaTime * _vx, 0f, Time.deltaTime * _vz);
 
         // 十分にターゲットが通り過ぎてしまったら
-        // if ((_vx > 0 && _transform.localPosition.x >= 2) ||
-        //     (_vx <= 0 && _transform.localPosition.x <= -2))
-        if (_transform.localPosition.z < _sensorB.transform.localPosition.z - _del_z)
+        if ((_vx > 0 && _transform.localPosition.x >= 2) ||
+            (_vx <= 0 && _transform.localPosition.x <= -2))
+        // if (_transform.localPosition.z < _sensorB.transform.localPosition.z - _del_z)
         {
             // オブジェクトを無効化
             this.gameObject.SetActive(false);

--- a/WirelessAR_Demo/Assets/Scenes/SampleScene.unity
+++ b/WirelessAR_Demo/Assets/Scenes/SampleScene.unity
@@ -2183,6 +2183,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _settings: {fileID: 1981522840}
   _msg_box: {fileID: 812647510}
+  _target: {fileID: 1371375972}
 --- !u!1 &1141816424
 GameObject:
   m_ObjectHideFlags: 0
@@ -3119,7 +3120,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _img: {fileID: 481780386}
   <IsForceForward>k__BackingField: 0
-  <Speed>k__BackingField: 0.01
+  <Speed>k__BackingField: 0.008
   _scene: {fileID: 644640082}
 --- !u!65 &1472536874
 BoxCollider:

--- a/WirelessAR_Demo/Assets/Scenes/SampleScene.unity
+++ b/WirelessAR_Demo/Assets/Scenes/SampleScene.unity
@@ -3934,7 +3934,7 @@ MonoBehaviour:
     - Key: {r: 0, g: 0, b: 1, a: 0}
       Value: 1
   <OrbitDegree>k__BackingField: 0
-  <IsRandom>k__BackingField: 0
+  <IsRandom>k__BackingField: 1
   <MinOrbitDegree>k__BackingField: -45
   <MaxOrbitDegree>k__BackingField: 45
   <IsOverwrite>k__BackingField: 1

--- a/WirelessAR_Demo/Assets/Scenes/SampleScene.unity
+++ b/WirelessAR_Demo/Assets/Scenes/SampleScene.unity
@@ -367,6 +367,7 @@ MonoBehaviour:
   _target: {fileID: 1371375972}
   _sensorA: {fileID: 1129057379}
   _settings: {fileID: 1981522840}
+  _scene: {fileID: 644640082}
 --- !u!1 &118343568
 GameObject:
   m_ObjectHideFlags: 0
@@ -3119,6 +3120,7 @@ MonoBehaviour:
   _img: {fileID: 481780386}
   <IsForceForward>k__BackingField: 0
   <Speed>k__BackingField: 0.01
+  _scene: {fileID: 644640082}
 --- !u!65 &1472536874
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -3938,6 +3940,7 @@ MonoBehaviour:
   <MinOrbitDegree>k__BackingField: -45
   <MaxOrbitDegree>k__BackingField: 45
   <IsOverwrite>k__BackingField: 1
+  _scene: {fileID: 644640082}
 --- !u!1 &2057568921
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### 主な実装
- 衝突データを構造化しローカルに保存
- 簡単に.xml形式で（拡張性なども考慮）
- ターゲット削除のタイミングをセンサーA通過後に修正

### 今後の予定
- 評価実験ではいくつかのパターンの軌道およびターゲット色を予定
- 終わったタイミングでファイル書き込み（現在はインスペクタから手動）