### PR TITLE
評価実験用の仕様へ変更

### DIFF
--- a/WirelessAR_Demo/Assets/Original/Scripts/DemoSettings.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/DemoSettings.cs
@@ -147,9 +147,6 @@ public class DemoSettings : MonoBehaviour
     {
         // MEMO: 初期化時にセッター機能しないためあらためて初期化
         this.Distance = this.Distance;
-
-        // ターゲット数を設定
-        _scene.SetTargetNum(this.Colors.GetTable().Count);
     }
 
     // Update is called once per frame

--- a/WirelessAR_Demo/Assets/Original/Scripts/SceneController.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/SceneController.cs
@@ -7,7 +7,7 @@ public class SceneController : MonoBehaviour
     /// <summary>
     /// 表示する障害物
     /// /// </summary>
-    [SerializeField] GameObject _target;
+    [SerializeField] List<GameObject> _targets;
 
     /// <summary>
     /// 衝突回数データ群
@@ -21,7 +21,8 @@ public class SceneController : MonoBehaviour
     {
         // 初期値は非表示
         // Enable, Disableで制御
-        _target.SetActive(false);
+        foreach (var target in _targets)
+            target.SetActive(false);
 
         // TODO: 衝突データの復元など...
     }

--- a/WirelessAR_Demo/Assets/Original/Scripts/SensorA.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/SensorA.cs
@@ -24,7 +24,9 @@ public class SensorA : MonoBehaviour
     
     Vector3 _init_pos;
     Vector3 _next_pos;
-    bool _fin;
+
+    [field: SerializeField]
+    public bool IsFin { get; private set; } = false;
 
     // Start is called before the first frame update
     void Start()
@@ -49,14 +51,15 @@ public class SensorA : MonoBehaviour
         if (other.gameObject.CompareTag("Player"))
         {
             // 総歩行距離歩いたか
-            if (this.transform.localPosition.z > _settings.Distdata)
+            if (this.transform.localPosition.z > _settings.Distdata ||
+                this.IsFin)
             {
-                if (!_fin)
-                {
+                // if (!)
+                // {
                     // メッセージボックスを正面に表示し終了
                     _msg_box.SetActive(true);
-                    _fin = true;
-                }
+                    this.IsFin = true;
+                // }
             }
             else
             {

--- a/WirelessAR_Demo/Assets/Original/Scripts/SensorA.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/SensorA.cs
@@ -20,7 +20,7 @@ public class SensorA : MonoBehaviour
 
     [SerializeField] DemoSettings _settings;
     [SerializeField] GameObject _msg_box;
-    [SerializeField] GameObject _target;
+    [SerializeField] List<GameObject> _targets;
     
     Vector3 _init_pos;
     Vector3 _next_pos;
@@ -63,7 +63,8 @@ public class SensorA : MonoBehaviour
             }
             else
             {
-                _target.SetActive(false);
+                foreach (var target in _targets)
+                    target.SetActive(false);
 
                 // 歩行開始とみなす
                 this.IsWalking = true;

--- a/WirelessAR_Demo/Assets/Original/Scripts/SensorB.cs
+++ b/WirelessAR_Demo/Assets/Original/Scripts/SensorB.cs
@@ -52,7 +52,7 @@ public class SensorB : MonoBehaviour
         (1, 0, 30),
         (1, 1, -20),
         (0, 1, 20),
-        (0, 0, 0),
+        (0, 0, 30),
         (0, 1, 0),
         (1, 0, -10),
         (1, 1, 10),  
@@ -157,7 +157,7 @@ public class SensorB : MonoBehaviour
                 // ターゲットの設定（評価実験用）
                 var target = sel_target.GetComponent<Target>();
                 target.SetColor(color.Value);
-                target.Id = _objs[_loop].color_id;
+                target.Id = _objs[_loop].id * _targets.Count + _objs[_loop].color_id;
                 target.Direction = angle <= 0 ? Direction.Left : Direction.Right;
 
                 // 出現情報を格納

--- a/WirelessAR_Demo/Assets/Scenes/SampleScene.unity
+++ b/WirelessAR_Demo/Assets/Scenes/SampleScene.unity
@@ -2203,6 +2203,7 @@ MonoBehaviour:
   _settings: {fileID: 1981522840}
   _msg_box: {fileID: 812647510}
   _target: {fileID: 1371375972}
+  <IsFin>k__BackingField: 0
 --- !u!1 &1141816424
 GameObject:
   m_ObjectHideFlags: 0
@@ -3437,7 +3438,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1610171613}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.267, y: 0, z: 0.6}
+  m_LocalPosition: {x: -1.267, y: -0.3, z: 0.6}
   m_LocalScale: {x: 0.1, y: 0.5, z: 0.1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -4077,8 +4078,8 @@ MonoBehaviour:
       Value: 1
   <OrbitDegree>k__BackingField: 0
   <IsRandom>k__BackingField: 1
-  <MinOrbitDegree>k__BackingField: -45
-  <MaxOrbitDegree>k__BackingField: 45
+  <MinOrbitDegree>k__BackingField: -40
+  <MaxOrbitDegree>k__BackingField: 40
   <IsOverwrite>k__BackingField: 1
   _scene: {fileID: 644640082}
 --- !u!1 &2057568921

--- a/WirelessAR_Demo/Assets/Scenes/SampleScene.unity
+++ b/WirelessAR_Demo/Assets/Scenes/SampleScene.unity
@@ -443,6 +443,25 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 118343568}
   m_CullTransparentMesh: 0
+--- !u!1 &167048318 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1352114948813630, guid: e13ee7e0790c7d243b7aa67fe604acac,
+    type: 3}
+  m_PrefabInstance: {fileID: 1472536868}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &167048319
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 167048318}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.45, y: 1.7, z: 0.3}
+  m_Center: {x: 0, y: -0.65, z: 0.15}
 --- !u!1 &211374481
 GameObject:
   m_ObjectHideFlags: 0
@@ -2690,8 +2709,8 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 0.8, y: 6, z: 1}
-  m_Center: {x: -0.1, y: -2.5, z: 0}
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &1371375974
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -3007,8 +3026,12 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 1352114948813630, guid: e13ee7e0790c7d243b7aa67fe604acac, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1352114948813630, guid: e13ee7e0790c7d243b7aa67fe604acac, type: 3}
       propertyPath: m_TagString
-      value: Untagged
+      value: Player
       objectReference: {fileID: 0}
     - target: {fileID: 1603769914748404, guid: e13ee7e0790c7d243b7aa67fe604acac, type: 3}
       propertyPath: m_Name
@@ -3073,6 +3096,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 114711245158774928, guid: e13ee7e0790c7d243b7aa67fe604acac,
         type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114711245158774928, guid: e13ee7e0790c7d243b7aa67fe604acac,
+        type: 3}
       propertyPath: streamInputIP
       value: 192.168.0.153
       objectReference: {fileID: 0}
@@ -3122,19 +3150,6 @@ MonoBehaviour:
   <IsForceForward>k__BackingField: 0
   <Speed>k__BackingField: 0.008
   _scene: {fileID: 644640082}
---- !u!65 &1472536874
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1472536871}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.7, y: 4, z: 0.3}
-  m_Center: {x: 0, y: 0, z: 0.15}
 --- !u!4 &1472536876 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4309805032874704, guid: e13ee7e0790c7d243b7aa67fe604acac,
@@ -3304,6 +3319,130 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1593752141}
   m_CullTransparentMesh: 0
+--- !u!1 &1610171613
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1610171619}
+  - component: {fileID: 1610171618}
+  - component: {fileID: 1610171617}
+  - component: {fileID: 1610171616}
+  - component: {fileID: 1610171615}
+  - component: {fileID: 1610171614}
+  m_Layer: 0
+  m_Name: LongTarget
+  m_TagString: Obstacle
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &1610171614
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1610171613}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d234d5135ced1b443b210a49a377087a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _sensorB: {fileID: 113069484}
+--- !u!54 &1610171615
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1610171613}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!65 &1610171616
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1610171613}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.8, y: 1, z: 1}
+  m_Center: {x: -0.1, y: 0, z: 0}
+--- !u!23 &1610171617
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1610171613}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1610171618
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1610171613}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1610171619
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1610171613}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.267, y: 0, z: 0.6}
+  m_LocalScale: {x: 0.1, y: 0.5, z: 0.1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1655201917
 GameObject:
   m_ObjectHideFlags: 0
@@ -3928,7 +4067,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <Speed>k__BackingField: 30
-  _distance: 3
+  _distance: 7
   _distdata: 0
   <Colors>k__BackingField:
     list:

--- a/WirelessAR_Demo/Assets/Scenes/SampleScene.unity
+++ b/WirelessAR_Demo/Assets/Scenes/SampleScene.unity
@@ -364,7 +364,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1ace5f55123ad9043a462e8f0ca25856, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _target: {fileID: 1371375972}
+  _targets:
+  - {fileID: 1371375972}
+  - {fileID: 1610171613}
   _sensorA: {fileID: 1129057379}
   _settings: {fileID: 1981522840}
   _scene: {fileID: 644640082}
@@ -1214,7 +1216,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ef795650854620a44921e8024d3f18de, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _target: {fileID: 1371375972}
+  _targets:
+  - {fileID: 1371375972}
+  - {fileID: 1610171613}
 --- !u!4 &644640083
 Transform:
   m_ObjectHideFlags: 0
@@ -2202,7 +2206,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _settings: {fileID: 1981522840}
   _msg_box: {fileID: 812647510}
-  _target: {fileID: 1371375972}
+  _targets:
+  - {fileID: 1371375972}
+  - {fileID: 1610171613}
   <IsFin>k__BackingField: 0
 --- !u!1 &1141816424
 GameObject:
@@ -3026,6 +3032,14 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1082135366421468, guid: e13ee7e0790c7d243b7aa67fe604acac, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1175467483869550, guid: e13ee7e0790c7d243b7aa67fe604acac, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1352114948813630, guid: e13ee7e0790c7d243b7aa67fe604acac, type: 3}
       propertyPath: m_IsActive
       value: 1
@@ -3045,6 +3059,10 @@ PrefabInstance:
     - target: {fileID: 1603769914748404, guid: e13ee7e0790c7d243b7aa67fe604acac, type: 3}
       propertyPath: m_TagString
       value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 1721814514466412, guid: e13ee7e0790c7d243b7aa67fe604acac, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4309805032874704, guid: e13ee7e0790c7d243b7aa67fe604acac, type: 3}
       propertyPath: m_RootOrder
@@ -3340,7 +3358,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &1610171614
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4078,8 +4096,8 @@ MonoBehaviour:
       Value: 1
   <OrbitDegree>k__BackingField: 0
   <IsRandom>k__BackingField: 1
-  <MinOrbitDegree>k__BackingField: -40
-  <MaxOrbitDegree>k__BackingField: 40
+  <MinOrbitDegree>k__BackingField: -45
+  <MaxOrbitDegree>k__BackingField: 45
   <IsOverwrite>k__BackingField: 1
   _scene: {fileID: 644640082}
 --- !u!1 &2057568921


### PR DESCRIPTION
### About
#### 任意の形のターゲット出現に対応
任意のオブジェクトorプレハブを該当スクリプトにアタッチ

#### 衝突結果の掃き出し
以前から対応してたのでそのまま（XML書き込み）
別カラーも別ターゲットとして扱っていることに注意

#### その他変更点
- 現在はハードコーディングでターゲットの (形=id, 色, 角度)をタプルで指定
- プレイヤーの当たり判定をなるべく人間の体形に近いBBに修正
- インスペクタから終了できるように変更

### MEMO
Unity側でターゲットを設定する箇所を1つにするべき（取り急ぎの実装のため複数スクリプトにアタッチしてます）